### PR TITLE
feat(tilt): add default Tiltfile template for common extensions

### DIFF
--- a/default.Tiltfile
+++ b/default.Tiltfile
@@ -1,0 +1,25 @@
+if not os.path.exists('extension_tiltfile'):
+  local('curl https://raw.githubusercontent.com/michaelmass/tiltfile-extensions/master/Tiltfile > extension_tiltfile', quiet=True)
+
+load(
+  './extension_tiltfile',
+  'bool_to_string',
+  'default_resources',
+  'default_settings',
+  'define_config',
+  'dict_merge',
+  'dict_omit',
+  'docker_compose_resources',
+  'docker_resource',
+  'dotenv_watch',
+  'open',
+  'postgres_uri',
+  'redis_uri',
+  'resource',
+  'set_mode',
+  'string_to_bool',
+  'write_file',
+)
+
+dotenv_watch()
+default_settings()


### PR DESCRIPTION
Addition of Default Tiltfile for Tilt Configuration

This PR adds a new `default.Tiltfile` file that serves as a template for integrating with the tiltfile-extensions repository. The file simplifies the process of importing common extensions and setting up a basic Tilt environment.
